### PR TITLE
Se añade api_url express

### DIFF
--- a/rxconfig.py
+++ b/rxconfig.py
@@ -1,5 +1,6 @@
 import reflex as rx
 
 config = rx.Config(
-    app_name="portafolio"
+    app_name="portafolio",
+    api_url="https://jomaroflo94-express-api.vercel.app:8000"
 )


### PR DESCRIPTION
Al añadir la api_url del servidor express api deja de aparecer el error ante la ausencia del backend